### PR TITLE
use fs.lchown rather than fs.chown and thereby fix #14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ---
-language: node_js
+language: generic
 
 sudo: required
 
@@ -7,14 +7,14 @@ services:
   - docker
 
 before_install:
-  - 'docker pull node/10.8.0-stretch'
+  - 'docker pull node:10.8.0-stretch'
 
 script:
   - container_id=$(mktemp)
-  - 'docker run --detach --volume="${PWD}":/root/chownr:rw --privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro node/10.8.0-stretch /lib/systemd/systemd > "${container_id}"'
+  - 'docker run --rm --detach --tty --init --volume="${PWD}":/root/chownr:rw --privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro node:10.8.0-stretch > "${container_id}"'
   - 'docker exec --tty "$(cat ${container_id})" df -h'
   - 'docker exec --tty "$(cat ${container_id})" nodejs -v'
   - 'docker exec --tty "$(cat ${container_id})" yarnpkg -v'
   - 'docker exec --tty "$(cat ${container_id})" npm -v'
-  - 'docker exec --tty "$(cat ${container_id})" -w /root/chownr yarnpkg install'
-  - 'docker exec --tty "$(cat ${container_id})" -w /root/chownr tap test/*.js'
+  - 'docker exec --tty -w /root/chownr "$(cat ${container_id})" yarnpkg install'
+  - 'docker exec --tty -w /root/chownr "$(cat ${container_id})" node_modules/tap/bin/run.js -Rspec test/*.js'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,20 @@
+---
 language: node_js
-node_js:
-  - '10.6.0'
+
+sudo: required
+
+services:
+  - docker
+
+before_install:
+  - 'docker pull node/10.8.0-stretch'
+
+script:
+  - container_id=$(mktemp)
+  - 'docker run --detach --volume="${PWD}":/root/chownr:rw --privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro node/10.8.0-stretch /lib/systemd/systemd > "${container_id}"'
+  - 'docker exec --tty "$(cat ${container_id})" df -h'
+  - 'docker exec --tty "$(cat ${container_id})" nodejs -v'
+  - 'docker exec --tty "$(cat ${container_id})" yarnpkg -v'
+  - 'docker exec --tty "$(cat ${container_id})" npm -v'
+  - 'docker exec --tty "$(cat ${container_id})" -w /root/chownr yarnpkg install'
+  - 'docker exec --tty "$(cat ${container_id})" -w /root/chownr tap test/*.js'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
 language: node_js
-before_script: npm install -g npm@latest
 node_js:
-  - '0.8'
-  - '0.10'
-  - '0.12'
-  - 'iojs'
+  - '10.6.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
   - docker
 
 before_install:
+  - 'docker -v'
   - 'docker pull node:10.8.0-stretch'
 
 script:
@@ -16,5 +17,5 @@ script:
   - 'docker exec --tty "$(cat ${container_id})" nodejs -v'
   - 'docker exec --tty "$(cat ${container_id})" yarnpkg -v'
   - 'docker exec --tty "$(cat ${container_id})" npm -v'
-  - 'docker exec --tty -w /root/chownr "$(cat ${container_id})" yarnpkg install'
-  - 'docker exec --tty -w /root/chownr "$(cat ${container_id})" node_modules/tap/bin/run.js -Rspec test/*.js'
+  - 'docker exec --tty "$(cat ${container_id})" /bin/sh -c "cd /root/chownr && yarnpkg install"'
+  - 'docker exec --tty "$(cat ${container_id})" /bin/sh -c "cd /root/chownr && node_modules/tap/bin/run.js -Rspec test/*.js"'

--- a/chownr.js
+++ b/chownr.js
@@ -15,19 +15,12 @@ function chownr (p, uid, gid, cb) {
     , errState = null
     children.forEach(function (child) {
       var pathChild = path.resolve(p, child);
-      fs.lstat(pathChild, function(er, stats) {
-        if (er)
-          return cb(er)
-        if (!stats.isSymbolicLink())
-          chownr(pathChild, uid, gid, then)
-        else
-          then()
-        })
+      chownr(pathChild, uid, gid, then)
     })
     function then (er) {
       if (errState) return
       if (er) return cb(errState = er)
-      if (-- len === 0) return fs.chown(p, uid, gid, cb)
+      if (-- len === 0) return fs.lchown(p, uid, gid, cb)
     }
   })
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,6 @@
   "scripts": {
     "test": "tap test/*.js"
   },
-  "license": "ISC"
+  "license": "ISC",
+  "engines": { "node" : ">=10.6.0" }
 }


### PR DESCRIPTION
fixes the symlinks problem #3 while not causing the TOCTOU vulnerability #14

The [patch in libuv 1.21.0](https://github.com/libuv/libuv/releases/tag/v1.21.0) that undeprecates `fs.lchown` [has been incorporated in nodejs Version 10.6.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#2018-07-04-version-1060-current-targos).

So I specified the minimum nodejs version in `package.json` with the `engine` key: https://docs.npmjs.com/files/package.json#engines